### PR TITLE
Add cosign install step before signing (fixes Build on main)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache,mode=max
+      - name: Install cosign
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:


### PR DESCRIPTION
Build has been failing on main with `xargs: cosign: No such file or directory` — the self-hosted runner doesn't have cosign installed. Adds `sigstore/cosign-installer` step before the Sign step.