### PR TITLE
Install cosign via curl on self-hosted runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,17 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache,mode=max
       - name: Install cosign
         if: ${{ github.event_name != 'pull_request' }}
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        run: |
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) dl_arch=amd64 ;;
+            aarch64|arm64) dl_arch=arm64 ;;
+            *) echo "Unsupported arch: $arch" >&2; exit 1 ;;
+          esac
+          curl -sSfL -o "$HOME/cosign" \
+            "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-${dl_arch}"
+          chmod +x "$HOME/cosign"
+          echo "$HOME" >> "$GITHUB_PATH"
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:


### PR DESCRIPTION
`sigstore/cosign-installer` invokes `envsubst` which isn't installed on Jeff's self-hosted ARM64 runners, so the previous fix step failed with exit code 127. Replace with a direct curl download of the cosign binary (arch-detected).