### PR TITLE
fix(chart): add RBAC and fix templating so the operator runs

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,22 +1,14 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "..fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "..fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "..fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "..name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+whisperer is installed and watching Secrets across all namespaces.
+
+To replicate a Secret into other namespaces, label and annotate the source Secret:
+
+  kubectl label secret <name> -n <source-ns> whisperer.jeffl.es/sync=true
+  kubectl annotate secret <name> -n <source-ns> \
+    whisperer.jeffl.es/namespaces=<ns1>,<ns2>,<ns3>
+
+whisperer will copy it into each listed namespace and keep the copies in sync —
+recreating any that are deleted, and removing all copies if the source is deleted.
+
+Check the operator:
+  kubectl --namespace {{ .Release.Namespace }} rollout status deploy/{{ include "..fullname" . }}
+  kubectl --namespace {{ .Release.Namespace }} logs -l app.kubernetes.io/name={{ include "..name" . }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,9 +62,9 @@ spec:
           {{- end }}
           env:
             - name: HEALTHCHECK_PORT
-              value: .Values.service.port
+              value: {{ .Values.service.port | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otelEndpoint }}
+              value: {{ .Values.otelEndpoint | quote }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.rbac.create -}}
+# Cluster-wide: the operator watches Secrets in all namespaces and replicates
+# them into the namespaces named by the whisperer.jeffl.es/namespaces annotation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "..fullname" . }}
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "..fullname" . }}
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "..fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "..serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+# Namespaced: leader election (election.rs) holds a Lease in the operator's own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "..fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "..fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "..fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "..serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# RBAC: the operator needs cluster-wide access to Secrets and Namespaces, plus a
+# Lease in its own namespace for leader election. Disable only if you manage RBAC
+# out of band.
+rbac:
+  create: true
+
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
The Helm chart was a `helm create` scaffold that couldn't actually run the secret-sync operator. This makes it deployable.

## Fixes
- **Add RBAC (the blocker).** The controller lists/watches Secrets cluster-wide, lists Namespaces, and holds a Lease for leader election (`election.rs`), but the chart shipped only a ServiceAccount — so the operator couldn't read or replicate anything. Adds a `ClusterRole`/`ClusterRoleBinding` (secrets + namespaces) and a namespaced `Role`/`RoleBinding` (leases), gated on a new `rbac.create` value (default `true`).
- **Fix `HEALTHCHECK_PORT` env.** Was the literal string `.Values.service.port` (not templated) and unquoted → now `{{ .Values.service.port | quote }}`.
- **Fix `NOTES.txt`.** Referenced `.Values.ingress.enabled`, which isn't in `values.yaml`, so `helm lint`/`helm template` errored. Replaced with usage notes for labelling/annotating a secret to sync.

## Verify
```
helm lint chart            # passes
helm template whisperer chart -n whisperer   # renders ClusterRole/Binding, Role/Binding, fixed env
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)