### PR TITLE
chore: fix clippy lints, wire up telemetry module, apply rustfmt

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,5 @@
 use crate::{
-    election::{start, LeaderState},
+    election::{LeaderState, start},
     error::{Error, Result},
     ext::SecretExt,
     labels::*,
@@ -8,16 +8,16 @@ use crate::{
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::{Namespace, ObjectReference, Secret};
 use kube::{
+    Api, Client, Resource, ResourceExt,
     api::{DeleteParams, ListParams, Patch, PatchParams},
     runtime::{
+        Controller,
         controller::{Action, Error as RuntimeError},
         events::{Event as Notice, EventType, Recorder, Reporter},
-        finalizer::{finalizer, Event},
+        finalizer::{Event, finalizer},
         reflector::ObjectRef,
         watcher::Config,
-        Controller,
     },
-    Api, Client, Resource, ResourceExt,
 };
 use std::{collections::HashSet, env, sync::Arc};
 use tokio::time::Duration;
@@ -54,7 +54,9 @@ async fn secret_namespaces(secret: Arc<Secret>, client: Client) -> Result<NSSet,
         .collect::<NSSet>();
     let annotations = secret.annotations();
     let wanted = if let Some(ns) = annotations.get(NAMESPACE_ANNOTATION) {
-        ns.split(",").map(|s| s.trim().to_string()).collect::<NSSet>()
+        ns.split(",")
+            .map(|s| s.trim().to_string())
+            .collect::<NSSet>()
     } else {
         let name = secret.name_any();
         let namespace = secret.namespace().unwrap_or(String::from(""));
@@ -73,7 +75,9 @@ async fn secret_namespaces(secret: Arc<Secret>, client: Client) -> Result<NSSet,
         let unk = difference.join(",");
         let name = secret.name_any();
         let namespace = secret.namespace().unwrap_or(String::from(""));
-        warn!("List label {NAMESPACE_ANNOTATION} on secret '{name}' in namespace '{namespace}' includes unknown namespaces '{unk}'");
+        warn!(
+            "List label {NAMESPACE_ANNOTATION} on secret '{name}' in namespace '{namespace}' includes unknown namespaces '{unk}'"
+        );
     }
     Ok(namespaces
         .intersection(&wanted)
@@ -233,7 +237,10 @@ async fn cleanup(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
 #[instrument(skip(ctx))]
 async fn dispatcher(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
     if !ctx.state.is_leader() {
-        info!("not leader (leader is {}), ignoring change", ctx.state.leader());
+        info!(
+            "not leader (leader is {}), ignoring change",
+            ctx.state.leader()
+        );
         return Ok(Action::await_change());
     }
     let metrics = ctx.metrics.clone();
@@ -312,15 +319,15 @@ mod test {
         metrics::MetricState,
     };
 
-    use super::{apply, cleanup, Context, ACTIVE_LABEL, NAMESPACE_ANNOTATION, WHISPER_LABEL};
+    use super::{ACTIVE_LABEL, Context, NAMESPACE_ANNOTATION, WHISPER_LABEL, apply, cleanup};
     use k8s_openapi::{
-        api::core::v1::{Namespace, Secret},
         ByteString,
+        api::core::v1::{Namespace, Secret},
     };
     use kube::{
+        Api, Client,
         api::{DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams},
         runtime::events::{Recorder, Reporter},
-        Api, Client,
     };
     use opentelemetry::metrics::MeterProvider;
     use opentelemetry_otlp::{MetricExporter, Protocol, WithExportConfig};

--- a/src/election.rs
+++ b/src/election.rs
@@ -26,7 +26,7 @@ pub(crate) enum State {
 
 impl State {
     fn is_leader(&self) -> bool {
-        matches!(self, State::Leading { .. })
+        matches!(self, State::Leading)
     }
 
     fn leader(&self) -> String {
@@ -197,7 +197,7 @@ async fn renew(state: State, api: Api<Lease>, change: Option<Lease>) -> Result<S
             let should_attempt_acquisition = lease
                 .spec
                 .clone()
-                .and_then(|spec| Some((spec.renew_time, spec.lease_duration_seconds)))
+                .map(|spec| (spec.renew_time, spec.lease_duration_seconds))
                 .and_then(|pair| match pair {
                     (Some(microtime), Some(seconds)) => {
                         Some(microtime.0 + Duration::from_secs(seconds as u64))
@@ -205,7 +205,7 @@ async fn renew(state: State, api: Api<Lease>, change: Option<Lease>) -> Result<S
                     (Some(microtime), None) => Some(microtime.0),
                     _ => None,
                 })
-                .map_or(true, |time| time < Timestamp::now());
+                .is_none_or(|time| time < Timestamp::now());
 
             if should_attempt_acquisition {
                 // Add jitter to reduce contention
@@ -269,7 +269,7 @@ pub(crate) async fn start(client: Client) -> (LeaderState, LeaderLock) {
     let (state_tx, state_rx) = watch::channel(State::Standby);
     let (cancel_tx, mut cancel_rx) = oneshot::channel();
     let namespace = client.default_namespace();
-    let api = Api::<Lease>::namespaced(client.clone(), &namespace);
+    let api = Api::<Lease>::namespaced(client.clone(), namespace);
     let handle = tokio::spawn(async move {
         let mut state = State::Standby;
         let owner: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
@@ -336,7 +336,7 @@ pub(crate) async fn start(client: Client) -> (LeaderState, LeaderLock) {
             }
         }
         // we're shutting down, cleanup our lease
-        if let State::Leading { .. } = state {
+        if let State::Leading = state {
             let pp = PatchParams::default();
             let patch = Patch::Apply(Lease {
                 spec: Some(LeaseSpec {
@@ -346,7 +346,7 @@ pub(crate) async fn start(client: Client) -> (LeaderState, LeaderLock) {
                 ..Default::default()
             });
             let _ = api
-                .patch(&LOCK_NAME, &pp, &patch)
+                .patch(LOCK_NAME, &pp, &patch)
                 .await
                 .map_err(Error::Patch)?;
             state_tx
@@ -376,9 +376,9 @@ mod test {
     use kube::{Api, Client, Config};
     use serde_json::json;
 
-    use crate::election::{get_hostname, LEASE_TIME};
+    use crate::election::{LEASE_TIME, get_hostname};
 
-    use super::{new_owner, renew, State};
+    use super::{State, new_owner, renew};
 
     #[tokio::test]
     async fn test_new_owner() {
@@ -389,7 +389,7 @@ mod test {
         });
         let client = Client::try_from(Config::new(server.url("/").parse().unwrap())).unwrap();
         let namespace = client.default_namespace();
-        let api = Api::<Lease>::namespaced(client.clone(), &namespace);
+        let api = Api::<Lease>::namespaced(client.clone(), namespace);
         let leader = get_hostname();
         let state = new_owner(
             State::Following {
@@ -433,7 +433,7 @@ mod test {
         let server = MockServer::start_async().await;
         let client = Client::try_from(Config::new(server.url("/").parse().unwrap())).unwrap();
         let namespace = client.default_namespace();
-        let api = Api::<Lease>::namespaced(client.clone(), &namespace);
+        let api = Api::<Lease>::namespaced(client.clone(), namespace);
         (server, api)
     }
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::Secret;
-use kube::{api::ObjectMeta, Resource, ResourceExt};
+use kube::{Resource, ResourceExt, api::ObjectMeta};
 
 use crate::labels::*;
 
@@ -15,7 +15,9 @@ impl SecretExt for Secret {
         let meta = self.meta();
         let name = self.name_any();
         let namespace = self.namespace().unwrap_or(String::from(""));
-        // I could an argument to see not syncing labels and annotations.
+        // Copy the source's labels and annotations, minus the ones that mark it
+        // as a sync source; there's an argument for not propagating them at all,
+        // but keeping them makes the copies easier to trace back.
         let mut labels = self
             .labels()
             .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,49 +1,22 @@
-use opentelemetry::{metrics::MeterProvider, trace::TracerProvider as _};
-use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
-use opentelemetry_sdk::{
-    metrics::SdkMeterProvider,
-    trace::{RandomIdGenerator, SdkTracerProvider},
-};
 use std::env;
-use tracing_subscriber::{fmt, layer::SubscriberExt, prelude::*, EnvFilter};
-use whisperer::{controller::run, metrics::MetricState, server::serve as server};
+use whisperer::{controller::run, server::serve as server, telemetry};
 
 // Ensure that we have a valid port
 fn port(var: &str) -> u16 {
     env::var(var)
-        .expect(&format!("{var} not defined"))
+        .unwrap_or_else(|_| panic!("{var} not defined"))
         .parse::<u16>()
-        .expect(&format!("{var} not a valid port"))
+        .unwrap_or_else(|_| panic!("{var} not a valid port"))
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let healthcheck_port = port("HEALTHCHECK_PORT");
-    let exporter = SpanExporter::builder().with_http().build()?;
-    let tracer = SdkTracerProvider::builder()
-        .with_id_generator(RandomIdGenerator::default())
-        .with_batch_exporter(exporter)
-        .build();
-    let otel = tracing_opentelemetry::layer().with_tracer(tracer.tracer("whisperer"));
-    let filter = EnvFilter::from_default_env();
-    tracing_subscriber::registry()
-        .with(otel)
-        .with(fmt::layer().with_filter(filter))
-        .init();
-
-    let exporter = MetricExporter::builder()
-        .with_http()
-        .with_protocol(Protocol::HttpBinary)
-        .build()?;
-    let provider = SdkMeterProvider::builder()
-        .with_periodic_exporter(exporter)
-        .build();
-    let meter = provider.meter("whisperer");
-    let state = MetricState::new(meter);
-    let controller = run(state.clone());
+    let telemetry = telemetry::init()?;
+    let controller = run(telemetry.metrics.clone());
     let server = server(healthcheck_port);
     tokio::join!(controller, server).1?;
-    provider.shutdown()?;
+    telemetry.shutdown()?;
     Ok(())
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
     KeyValue,
+    metrics::{Counter, Histogram, Meter},
 };
 
 // this file is neat! I'm proud of it.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Result};
-use axum::{routing::get, Router};
+use anyhow::{Result, anyhow};
+use axum::{Router, routing::get};
 use tokio::net::TcpListener;
 
 use crate::utils::shutdown_signal;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,7 +1,70 @@
-use crate::error::Result;
+use anyhow::Result;
+use opentelemetry::{metrics::MeterProvider, trace::TracerProvider as _};
+use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::{
+    metrics::SdkMeterProvider,
+    trace::{RandomIdGenerator, SdkTracerProvider},
+};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, prelude::*};
 
-// do this: https://github.com/kube-rs/controller-rs/blob/main/src/telemetry.rs
-// inspired by this: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp/src/main.rs
-pub fn telemetry() -> Result<()> {
-    Ok(())
+use crate::metrics::MetricState;
+
+// Telemetry setup follows the patterns from:
+// - https://github.com/kube-rs/controller-rs/blob/main/src/telemetry.rs
+// - https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+
+/// Owns the OpenTelemetry trace and metric pipelines for the process lifetime.
+///
+/// Hold this for as long as the program runs and call [`Telemetry::shutdown`]
+/// before exit so buffered spans and metrics are flushed to the collector.
+pub struct Telemetry {
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+    /// Metric recorders handed to the controller.
+    pub metrics: MetricState,
+}
+
+impl Telemetry {
+    /// Flush and tear down both pipelines. Call once, before exit.
+    pub fn shutdown(self) -> Result<()> {
+        // Flush metrics first, then traces, so any spans emitted while the
+        // meter shuts down are still captured.
+        self.meter_provider.shutdown()?;
+        self.tracer_provider.shutdown()?;
+        Ok(())
+    }
+}
+
+/// Initialize the tracing subscriber and OTLP exporters.
+///
+/// Installs a global subscriber combining an OpenTelemetry span layer with a
+/// `RUST_LOG`-filtered fmt layer, and wires up a periodic metric exporter.
+/// Returns a [`Telemetry`] guard that must be kept alive and shut down on exit.
+pub fn init() -> Result<Telemetry> {
+    let span_exporter = SpanExporter::builder().with_http().build()?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_id_generator(RandomIdGenerator::default())
+        .with_batch_exporter(span_exporter)
+        .build();
+    let otel = tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("whisperer"));
+    let filter = EnvFilter::from_default_env();
+    tracing_subscriber::registry()
+        .with(otel)
+        .with(fmt::layer().with_filter(filter))
+        .init();
+
+    let metric_exporter = MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()?;
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(metric_exporter)
+        .build();
+    let metrics = MetricState::new(meter_provider.meter("whisperer"));
+
+    Ok(Telemetry {
+        tracer_provider,
+        meter_provider,
+        metrics,
+    })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use tokio::signal::{
     ctrl_c,
-    unix::{signal, SignalKind},
+    unix::{SignalKind, signal},
 };
 
 pub(crate) async fn shutdown_signal() {


### PR DESCRIPTION
## Summary

Pure code cleanup — **no behavioral change** to the controller. Split out from a larger session so the security remediation work (see below) lands separately.

- **clippy** (`election.rs`, `main.rs`): cleared all `--all-targets` warnings — `is_none_or`, `map` instead of `and_then(|x| Some(..))`, dropped needless borrows, removed redundant unit-variant struct patterns, replaced `expect(&format!())` with `unwrap_or_else(|| panic!())`.
- **telemetry.rs**: replaced the empty stub with a real `Telemetry` guard that owns the OTLP trace + metric pipelines and flushes them on shutdown; `main.rs` now calls `telemetry::init()` instead of wiring tracing up inline (closes the `telemetry.rs` stub TODO in CLAUDE.md).
- **ext.rs**: clarified the `dup()` label/annotation-stripping comment.
- **rustfmt** across the tree (import ordering, 2024 style).

## Verification

- `cargo clippy --all-targets`: clean (was 9 warnings)
- `cargo nextest run`: 7 passed, 1 skipped
- `cargo fmt --check`: clean

## Note

A security review run this session surfaced a **Critical cross-tenant secret-injection** flaw plus 4 High findings (pre-existing on `main`, not touched by this PR). Those are tracked separately and **block the next release** — do not tag until they're addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)