### PR TITLE
fix(security): gate cross-namespace sync on consent, verify deletes, harden chart & CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
-name: Dependabot Auto-Merge
-on: pull_request
+name: Dependabot auto-merge
+on: pull_request_target
 
 permissions:
   contents: write
@@ -10,26 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve minor and patch updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr review --approve "$PR_URL"
+      # `gh pr merge --auto` only completes once the branch's required status
+      # checks pass, so the `rust` / `cargo audit` job must be marked required in
+      # branch protection for this to act as a real CI gate. We restrict auto
+      # handling to patch and minor bumps; majors require a human.
+      - name: Approve and enable auto-merge
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for minor and patch updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -25,6 +25,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # First-party installer verifies the cosign binary's own checksum.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1
         env:
@@ -34,6 +37,7 @@ jobs:
           skip_upload: true
       - name: Push charts to GHCR
         run: |
+          set -euo pipefail
           shopt -s nullglob
           for pkg in .cr-release-packages/*; do
             if [ -z "${pkg:-}" ]; then
@@ -41,5 +45,7 @@ jobs:
             fi
             helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts" &> push-metadata.txt
             CHART_DIGEST=$(awk '/Digest: /{print $2}' push-metadata.txt)
+            # Refuse to sign an empty/garbled ref if the push output format changes.
+            [[ "$CHART_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "missing/invalid chart digest: '$CHART_DIGEST'" >&2; cat push-metadata.txt >&2; exit 1; }
             cosign sign -y "ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts@${CHART_DIGEST}"
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,12 @@ jobs:
     permissions:
       contents: read
     runs-on: whisperer-runners
+    # The runners are self-hosted and persistent, so never execute code from a
+    # forked pull request on them — that would be arbitrary code execution on
+    # the build infrastructure. Push events and same-repo PRs are fine.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
     - name: Enable rust
       run: |
@@ -68,22 +74,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache,mode=max
+      # First-party installer verifies the cosign binary's own checksum, unlike
+      # a bare curl|chmod of a release asset.
       - name: Install cosign
         if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          arch=$(uname -m)
-          case "$arch" in
-            x86_64) dl_arch=amd64 ;;
-            aarch64|arm64) dl_arch=arm64 ;;
-            *) echo "Unsupported arch: $arch" >&2; exit 1 ;;
-          esac
-          curl -sSfL -o "$HOME/cosign" \
-            "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-${dl_arch}"
-          chmod +x "$HOME/cosign"
-          echo "$HOME" >> "$GITHUB_PATH"
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        run: |
+          set -euo pipefail
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "missing/invalid build digest: '$DIGEST'" >&2; exit 1; }
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,18 @@ RUN --mount=type=cache,target=/app/target,sharing=locked \
 RUN --mount=type=cache,target=/app/target,sharing=locked \
     cp /app/target/release/whisperer ./whisperer
 
-FROM rust:latest
-RUN useradd nonroot
-COPY --from=builder --chown=nonroot:nonroot /app/whisperer /app/
-USER nonroot
+# Slim runtime instead of the full rust image. Create a fixed-UID non-root user
+# (65532) so it matches the chart's securityContext.runAsUser/runAsGroup and the
+# pod can satisfy runAsNonRoot. ca-certificates is needed for TLS to the API
+# server and the OTLP endpoint. The binary is dynamically linked against glibc,
+# which the cargo-chef builder and bookworm-slim both provide.
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --uid 65532 --user-group --no-create-home --shell /usr/sbin/nologin nonroot
+COPY --from=builder --chown=65532:65532 /app/whisperer /app/whisperer
+USER 65532:65532
 HEALTHCHECK NONE
 EXPOSE 8080
 ENTRYPOINT ["/app/whisperer"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ I'm glad you asked, the trick is in the labels and annotations on the secret its
 
 The label `whisperer.jeffl.es/sync` tells the operator to sync the secret to the comma separated namespaces in the annotation `whisperer.jeffl.es/namespaces`. (BTW, **whisperer** will complain about the `missing` namespace here, but if you create it, it'll eventually catch up, like in 300 seconds or so. That's a lot, but maybe that's on you for whispering to an imaginary friend? You do you.)
 
+**One catch: target namespaces have to opt in.** whisperer will only copy a secret into a namespace that has consented by carrying the label `whisperer.jeffl.es/allow-sync=true`. Namespaces without it — and the protected `kube-system`, `kube-public`, `kube-node-lease`, and the operator's own namespace — are skipped. That's what stops anyone who can create a Secret from whispering it into a namespace they don't own. Label your targets first:
+```
+$ kubectl label namespace target whisperer.jeffl.es/allow-sync=true
+$ kubectl label namespace target2 whisperer.jeffl.es/allow-sync=true
+```
+
 There are a couple other niceties as well. You can delete a synced secret and it'll come right back:
 ```
 $ kubectl delete secret -n target sync

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,8 +10,10 @@ image:
   repository: ghcr.io/thejefflarson/whisperer
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  # Overrides the image tag whose default is the chart appVersion. Leave empty
+  # to pull the exact, cosign-signed version this chart was published for; a
+  # floating tag like "latest" would defeat that signature/digest pinning.
+  tag: ""
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -44,16 +46,25 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Hardened by default: this pod holds a token that can read and write Secrets
+# cluster-wide, so it runs as an unprivileged, non-root user with a read-only
+# root filesystem and no Linux capabilities to shrink the blast radius of any
+# compromise. Requires the image to be runnable as a non-root UID.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -41,21 +41,70 @@ impl Context {
 
 type NSSet = HashSet<String>;
 
-/// Returns a list of existing namespaces from a secret's namespace annotation:
-/// whisperer.jeffl.es/namespaces. It is an error to sync a secret without the namespace
-/// annotation. Unknown namespaces are ignored.
+/// Namespaces that may never receive synced secrets, regardless of labels.
+/// Writing into these could let a tenant tamper with cluster-critical secrets.
+const PROTECTED_NAMESPACES: &[&str] = &["kube-system", "kube-public", "kube-node-lease"];
+
+/// True if `ns` must never be used as a sync target. Covers the well-known
+/// system namespaces plus the operator's own namespace (set via the
+/// `CONTROLLER_NAMESPACE` env var) so a tenant can't target the controller.
+fn is_protected_namespace(ns: &str) -> bool {
+    PROTECTED_NAMESPACES.contains(&ns)
+        || env::var("CONTROLLER_NAMESPACE").ok().as_deref() == Some(ns)
+}
+
+/// True only for secrets whisperer itself created: they carry the `whisper`
+/// marker label AND were last applied by our field manager. The labels alone
+/// are forgeable by any tenant, but `managedFields` is maintained by the API
+/// server, so requiring our manager prevents a crafted look-alike secret from
+/// tricking the operator into deleting a victim's data.
+fn is_managed_copy(secret: &Secret) -> bool {
+    let marked = secret
+        .labels()
+        .get(WHISPER_LABEL)
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    let ours = secret.meta().managed_fields.as_ref().is_some_and(|fields| {
+        fields
+            .iter()
+            .any(|f| f.manager.as_deref() == Some(FIELD_MANAGER))
+    });
+    marked && ours
+}
+
+/// Resolve the set of namespaces a secret should be synced into.
+///
+/// The target list comes from the user-authored `whisperer.jeffl.es/namespaces`
+/// annotation, but a namespace is only an eligible target if it has explicitly
+/// opted in with `whisperer.jeffl.es/allow-sync=true` and is not protected.
+/// This consent check is the authorization boundary: without it any user who
+/// can create a Secret could copy data into namespaces they don't control.
+/// It is an error to sync a secret without the namespace annotation.
 async fn secret_namespaces(secret: Arc<Secret>, client: Client) -> Result<NSSet, Error> {
-    let namespaces = Api::<Namespace>::all(client.clone())
+    let all = Api::<Namespace>::all(client.clone())
         .list(&ListParams::default())
         .await
-        .map_err(Error::ListNamespaces)?
+        .map_err(Error::ListNamespaces)?;
+    let existing = all.iter().map(|ns| ns.name_any()).collect::<NSSet>();
+    let consenting = all
         .iter()
+        .filter(|ns| {
+            let name = ns.name_any();
+            !is_protected_namespace(&name)
+                && ns
+                    .labels()
+                    .get(ALLOW_SYNC_LABEL)
+                    .map(|v| v == "true")
+                    .unwrap_or(false)
+        })
         .map(|ns| ns.name_any())
         .collect::<NSSet>();
+
     let annotations = secret.annotations();
     let wanted = if let Some(ns) = annotations.get(NAMESPACE_ANNOTATION) {
-        ns.split(",")
+        ns.split(',')
             .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
             .collect::<NSSet>()
     } else {
         let name = secret.name_any();
@@ -67,22 +116,31 @@ async fn secret_namespaces(secret: Arc<Secret>, client: Client) -> Result<NSSet,
         error!(error = ?error, "missing namespace annotation {NAMESPACE_ANNOTATION} on secret '{name}' in namespace '{namespace}', not syncing");
         return Err(error);
     };
-    let difference = wanted
-        .difference(&namespaces)
-        .cloned()
-        .collect::<Vec<String>>();
-    if !difference.is_empty() {
-        let unk = difference.join(",");
-        let name = secret.name_any();
-        let namespace = secret.namespace().unwrap_or(String::from(""));
+
+    let name = secret.name_any();
+    let namespace = secret.namespace().unwrap_or(String::from(""));
+    let unknown = wanted.difference(&existing).cloned().collect::<Vec<_>>();
+    if !unknown.is_empty() {
         warn!(
-            "List label {NAMESPACE_ANNOTATION} on secret '{name}' in namespace '{namespace}' includes unknown namespaces '{unk}'"
+            "annotation {NAMESPACE_ANNOTATION} on secret '{name}' in namespace '{namespace}' includes unknown namespaces '{}'",
+            unknown.join(",")
         );
     }
-    Ok(namespaces
-        .intersection(&wanted)
-        .map(|k| k.to_owned())
-        .collect::<NSSet>())
+    // Requested namespaces that exist but have not opted in are refused — this
+    // is where a cross-tenant injection attempt gets dropped.
+    let refused = wanted
+        .iter()
+        .filter(|n| existing.contains(*n) && !consenting.contains(*n))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !refused.is_empty() {
+        warn!(
+            "secret '{name}' in namespace '{namespace}' requested namespaces '{}' that have not opted in via {ALLOW_SYNC_LABEL}=true; refusing to sync there",
+            refused.join(",")
+        );
+    }
+
+    Ok(wanted.intersection(&consenting).cloned().collect::<NSSet>())
 }
 
 /// The main reconcile function. The algorithm here is simple:
@@ -106,16 +164,22 @@ async fn apply(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action, Error> 
     let intersection = secret_namespaces(secret.clone(), client.clone()).await?;
 
     // If our list of namespaces has changed remove the old orphaned secrets.
+    // Scope to copies we actually marked (whisper=true) for this source.
     let lp = ListParams {
-        label_selector: Some(format!("{NAMESPACE_LABEL}={namespace},{NAME_LABEL}={name}")),
+        label_selector: Some(format!(
+            "{WHISPER_LABEL}=true,{NAMESPACE_LABEL}={namespace},{NAME_LABEL}={name}"
+        )),
         ..Default::default()
     };
     let api = Api::<Secret>::all(client.clone());
     let orphans = api.list(&lp).await.map_err(Error::ListSecrets)?;
-    // An orphan is a Secret that matches our source name, but isn't in our namespace list.
-    // We delete it here.
+    // An orphan is a managed copy of our source that is no longer in the target
+    // list. We verify managed-copy origin (not just labels) before deleting so a
+    // forged look-alike can't redirect the delete at a victim's secret.
     let orphans = orphans.iter().filter(|it| {
-        it.name_any() == name && !intersection.contains(&it.namespace().unwrap_or(String::from("")))
+        it.name_any() == name
+            && is_managed_copy(it)
+            && !intersection.contains(&it.namespace().unwrap_or(String::from("")))
     });
     for orphan in orphans {
         let ns = orphan.namespace().unwrap_or(String::from(""));
@@ -146,7 +210,7 @@ async fn apply(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action, Error> 
         let secret = (*secret).clone().dup(ns.clone());
         let patch = Patch::Apply(&secret);
         let res = api
-            .patch(&name, &PatchParams::apply("whisperer.jeffl.es"), &patch)
+            .patch(&name, &PatchParams::apply(FIELD_MANAGER), &patch)
             .await
             .map_err(Error::Patch)?;
         ctx.record(
@@ -174,6 +238,24 @@ async fn delete(name: String, namespace: String, ctx: Arc<Context>) -> Result<()
         .map_left(|_| info!("deleting secret {name} in {namespace}"))
         .map_right(|_| info!("deleted secret {name} in {namespace}"));
     Ok(())
+}
+
+/// Delete a secret only if it is genuinely a whisperer-managed copy.
+///
+/// Used for every cross-namespace delete: we fetch the target and confirm it
+/// passes [`is_managed_copy`] before removing it, so a tenant who plants a
+/// look-alike secret (right name/labels, wrong origin) can't trick the operator
+/// into destroying their data. A missing secret is a no-op.
+async fn delete_copy(name: String, namespace: String, ctx: Arc<Context>) -> Result<()> {
+    let api: Api<Secret> = Api::namespaced(ctx.client.clone(), &namespace);
+    match api.get_opt(&name).await.map_err(Error::GetSecret)? {
+        Some(secret) if is_managed_copy(&secret) => delete(name, namespace, ctx).await,
+        Some(_) => {
+            warn!("refusing to delete secret {name} in {namespace}: not a whisperer-managed copy");
+            Ok(())
+        }
+        None => Ok(()),
+    }
 }
 
 /// Does three things:
@@ -206,7 +288,7 @@ async fn cleanup(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
     )
     .await?;
     for ns in union.clone() {
-        delete(name.clone(), ns, ctx.clone()).await?;
+        delete_copy(name.clone(), ns, ctx.clone()).await?;
     }
 
     // And just to be absolutely sure we delete any remaining secrets that have our child labels on them,
@@ -227,7 +309,8 @@ async fn cleanup(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
         .map_err(Error::ListSecrets)?;
     for secret in secrets {
         let namespace = secret.namespace().unwrap_or(String::from(""));
-        if !union.contains(&namespace) {
+        // We hold the object here, so verify origin directly before deleting.
+        if !union.contains(&namespace) && is_managed_copy(&secret) {
             delete(secret.name_any(), namespace, ctx.clone()).await?;
         }
     }
@@ -245,12 +328,11 @@ async fn dispatcher(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
     }
     let metrics = ctx.metrics.clone();
     let namespace = secret.namespace().unwrap_or(String::from(""));
-    let name = secret.name_any();
-    // NEAT! It's very cool that this sticks around across threads and await, rust is excellent
-    let _ = metrics.duration(namespace.clone(), name.clone());
+    // Hold the duration guard for the whole reconcile; it records on drop.
+    let _record = metrics.duration();
     let api: Api<Secret> = Api::namespaced(ctx.client.clone(), &namespace);
     finalizer(&api, FINALIZER, secret, |event| async {
-        metrics.reconcile(namespace.clone(), name.clone());
+        metrics.reconcile();
         match event {
             Event::Apply(secret) => apply(secret, ctx).await,
             Event::Cleanup(secret) => cleanup(secret, ctx).await,
@@ -258,7 +340,7 @@ async fn dispatcher(secret: Arc<Secret>, ctx: Arc<Context>) -> Result<Action> {
     })
     .await
     .map_err(|e| {
-        metrics.failure(namespace.clone(), name);
+        metrics.failure();
         Error::Finalizer(Box::new(e))
     })
 }
@@ -319,11 +401,76 @@ mod test {
         metrics::MetricState,
     };
 
-    use super::{ACTIVE_LABEL, Context, NAMESPACE_ANNOTATION, WHISPER_LABEL, apply, cleanup};
+    use super::{
+        ACTIVE_LABEL, Context, NAMESPACE_ANNOTATION, WHISPER_LABEL, apply, cleanup,
+        is_managed_copy, is_protected_namespace,
+    };
+    use crate::labels::{FIELD_MANAGER, NAME_LABEL, NAMESPACE_LABEL};
     use k8s_openapi::{
         ByteString,
         api::core::v1::{Namespace, Secret},
+        apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry,
     };
+
+    fn copy_with(labels: &[(&str, &str)], manager: Option<&str>) -> Secret {
+        use kube::api::ObjectMeta;
+        use std::collections::BTreeMap;
+        Secret {
+            metadata: ObjectMeta {
+                labels: Some(
+                    labels
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect::<BTreeMap<_, _>>(),
+                ),
+                managed_fields: manager.map(|m| {
+                    vec![ManagedFieldsEntry {
+                        manager: Some(m.to_string()),
+                        ..Default::default()
+                    }]
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn protected_namespaces_are_rejected() {
+        assert!(is_protected_namespace("kube-system"));
+        assert!(is_protected_namespace("kube-public"));
+        assert!(is_protected_namespace("kube-node-lease"));
+        assert!(!is_protected_namespace("team-a"));
+    }
+
+    #[test]
+    fn managed_copy_requires_both_marker_and_field_manager() {
+        // genuine copy: whisper=true AND our field manager
+        assert!(is_managed_copy(&copy_with(
+            &[
+                (WHISPER_LABEL, "true"),
+                (NAME_LABEL, "db"),
+                (NAMESPACE_LABEL, "src")
+            ],
+            Some(FIELD_MANAGER),
+        )));
+        // forged labels but written by someone else -> not ours, must not delete
+        assert!(!is_managed_copy(&copy_with(
+            &[
+                (WHISPER_LABEL, "true"),
+                (NAME_LABEL, "db"),
+                (NAMESPACE_LABEL, "src")
+            ],
+            Some("attacker"),
+        )));
+        // our manager but no whisper marker -> not a managed copy
+        assert!(!is_managed_copy(&copy_with(
+            &[(NAME_LABEL, "db")],
+            Some(FIELD_MANAGER),
+        )));
+        // nothing -> not a managed copy
+        assert!(!is_managed_copy(&copy_with(&[], None)));
+    }
     use kube::{
         Api, Client,
         api::{DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams},

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     ListNamespaces(#[source] kube::Error),
     #[error("Could not retrieve secrets: {0}")]
     ListSecrets(#[source] kube::Error),
+    #[error("Could not retrieve secret: {0}")]
+    GetSecret(#[source] kube::Error),
     #[error("Could not find label {ACTIVE_LABEL} for secret {name} in namespace {namespace}")]
     MissingLabel { name: String, namespace: String },
     #[error("Could not find destination annotation for secret {name} in namespace {namespace}")]
@@ -36,9 +38,3 @@ pub enum Error {
     ChannelSend,
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-impl Error {
-    pub fn metric_label(&self) -> String {
-        format!("{self:?}").to_lowercase()
-    }
-}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -4,3 +4,14 @@ pub(crate) const WHISPER_LABEL: &str = "whisperer.jeffl.es/whisper";
 pub(crate) const NAME_LABEL: &str = "whisperer.jeffl.es/name";
 pub(crate) const NAMESPACE_LABEL: &str = "whisperer.jeffl.es/namespace";
 pub(crate) const FINALIZER: &str = "whisperer.jeffl.es/cleanup";
+
+/// A target namespace must carry this label set to `"true"` before whisperer
+/// will sync any secret into it. This is the authorization boundary that stops
+/// an arbitrary secret author from copying data into namespaces they don't own.
+pub(crate) const ALLOW_SYNC_LABEL: &str = "whisperer.jeffl.es/allow-sync";
+
+/// Server-side-apply field manager used for every secret whisperer writes.
+/// Copies carry this manager in their `managedFields`, which (unlike the
+/// `whisper`/`name`/`namespace` labels) a tenant cannot forge — so we use it to
+/// confirm a secret is genuinely operator-managed before deleting it.
+pub(crate) const FIELD_MANAGER: &str = "whisperer.jeffl.es";

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,10 +3,7 @@ use std::{
     time::SystemTime,
 };
 
-use opentelemetry::{
-    KeyValue,
-    metrics::{Counter, Histogram, Meter},
-};
+use opentelemetry::metrics::{Counter, Histogram, Meter};
 
 // this file is neat! I'm proud of it.
 
@@ -42,6 +39,11 @@ pub struct MetricState {
     inner: Arc<RwLock<Metrics>>,
 }
 
+// These metrics deliberately carry NO per-secret attributes. The secret name
+// and namespace are attacker-controlled, so using them as metric labels would
+// let anyone who can create secrets mint unbounded time series and exhaust the
+// operator's and the collector's memory. Per-object detail belongs in logs and
+// traces, where cardinality is not a resource-exhaustion vector.
 impl MetricState {
     pub fn new(meter: Meter) -> Self {
         Self {
@@ -49,54 +51,37 @@ impl MetricState {
         }
     }
 
-    pub fn reconcile(&self, key: String, value: String) {
-        self.inner
-            .write()
-            .unwrap()
-            .reconciliations
-            .add(1, &[KeyValue::new(key, value)])
+    pub fn reconcile(&self) {
+        self.inner.write().unwrap().reconciliations.add(1, &[])
     }
 
-    pub fn failure(&self, key: String, value: String) {
-        self.inner
-            .write()
-            .unwrap()
-            .failures
-            .add(1, &[KeyValue::new(key, value)])
+    pub fn failure(&self) {
+        self.inner.write().unwrap().failures.add(1, &[])
     }
 
-    pub fn duration(&self, key: String, value: String) -> Record {
+    pub fn duration(&self) -> Record {
         Record {
             start: SystemTime::now(),
             metrics: self.clone(),
-            key,
-            value,
         }
     }
 
-    fn finish(&self, millis: f64, key: String, value: String) {
-        self.inner
-            .write()
-            .unwrap()
-            .duration
-            .record(millis, &[KeyValue::new(key, value)]);
+    fn finish(&self, millis: f64) {
+        self.inner.write().unwrap().duration.record(millis, &[]);
     }
 }
 
 pub struct Record {
     start: SystemTime,
     metrics: MetricState,
-    key: String,
-    value: String,
 }
 
 impl Drop for Record {
     fn drop(&mut self) {
-        let diff = self.start.elapsed().unwrap();
-        self.metrics.finish(
-            diff.as_millis() as f64,
-            self.key.clone(),
-            self.value.clone(),
-        )
+        // `elapsed()` errors only if the clock went backwards; treat that as a
+        // zero-length sample rather than panicking inside a Drop (a panic here,
+        // during unwinding, would abort the whole process).
+        let diff = self.start.elapsed().unwrap_or_default();
+        self.metrics.finish(diff.as_millis() as f64)
     }
 }


### PR DESCRIPTION
Addresses the findings from this session's security review (**1 Critical, 4 High**, plus Mediums/Lows). Two root causes: the controller trusted user-authored labels/annotations for both *where it writes* and *what it deletes*, and the CI/CD pipeline ran untrusted code on persistent runners with an unverified signer.

## ⚠️ Behavior change
Existing sync targets **must** now be labelled `whisperer.jeffl.es/allow-sync=true` or their copies will stop being updated. Documented in the README.

## Controller (`src/`)
- **Critical — cross-tenant injection**: a target namespace must opt in with `whisperer.jeffl.es/allow-sync=true` before any secret is synced into it; non-consenting namespaces are warned + skipped. This is the authorization boundary that was missing.
- **High — no deny-list**: `kube-system`, `kube-public`, `kube-node-lease`, and the operator's own namespace (`CONTROLLER_NAMESPACE`) can never be sync targets.
- **High — spoofable-label deletion**: every cross-namespace delete now goes through `is_managed_copy()`, which requires both the `whisper` marker **and** our server-side-apply field manager (unforgeable by a tenant) before removing a secret. Orphan selector also scoped to `whisper=true`.
- **Low — metric cardinality**: dropped user-controlled name/namespace from metric labels (aggregate by outcome). `Record::drop` no longer panics on clock skew. Removed dead, leaky `Error::metric_label()`.
- Added unit tests for `is_protected_namespace` and `is_managed_copy`.

## Image + Chart
- **Dockerfile**: runtime stage switched from `rust:latest` (root, large) to `debian:bookworm-slim` with a **fixed-UID 65532 non-root user** + `ca-certificates`, so the pod satisfies the new `runAsNonRoot`/`runAsUser`.
- Secure-by-default `securityContext`: `runAsNonRoot`, `runAsUser: 65532`, `readOnlyRootFilesystem`, drop `ALL` caps, seccomp `RuntimeDefault`.
- `image.tag` defaults to `""` (chart appVersion) instead of mutable `latest`, restoring cosign digest pinning.

## CI/CD (`.github/workflows/`)
- **rust.yml**: the self-hosted `rust` job no longer runs on forked PRs (was RCE on build infra); cosign installed via the verified, SHA-pinned first-party `sigstore/cosign-installer` (v3.10.0) instead of `curl | chmod`; build digest validated before signing.
- **helm.yaml**: install cosign via the same pinned installer; chart-digest validated before signing; `set -euo pipefail`.
- **dependabot-auto-merge.yml**: switched to `pull_request_target`; auto-approve+merge restricted to patch/minor; documented that `--auto` relies on **required branch-protection checks** as the actual CI gate (please mark the `rust` job required).

## Verified locally
- `cargo nextest run`: **9 passed, 1 skipped**
- `cargo fmt --check`: clean
- `helm lint`: clean; `helm template` renders the hardening correctly
- all three workflow YAML files parse

## Caveats
- **Image not built locally** (no Docker daemon in the dev environment) — the `debian:bookworm-slim` runtime + non-root UID is built by CI on merge. **Verify the container starts and reaches the API server before tagging a release.**
- clippy: depended on #107 (now merged) for the pre-existing lint fixes; this branch adds no new lints.
- RBAC ClusterRole scope and SA-token automount were reviewed and intentionally kept — required for a cross-namespace syncer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
