### PR TITLE
docs: add ADRs for sync authorization and security remediation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,4 +106,4 @@ Prefer recording a new decision as an ADR (or a note in this file) over leaving 
 
 ## Known Issues / TODOs
 
-- `telemetry.rs` is a stub; tracing setup lives in `main.rs` directly._(resolved: `telemetry.rs` now owns the OTLP pipelines and sets `service.name`.)_
+- _None currently. (`telemetry.rs` now owns the OTLP pipelines and sets `service.name`; the runtime image is `debian:bookworm-slim` running as non-root UID 65532.)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,22 @@ Key Helm values: `image.repository`, `image.tag`, `otelEndpoint`.
 
 - Secret data is never logged.
 - Syncing requires explicit opt-in (`whisperer.jeffl.es/sync=true`).
+- Target namespaces must consent with `whisperer.jeffl.es/allow-sync=true`; protected namespaces (`kube-system`, `kube-public`, `kube-node-lease`, the operator's own `CONTROLLER_NAMESPACE`) are never targets. See [ADR 0001](docs/adr/0001-cross-namespace-sync-authorization.md).
+- Cross-namespace deletes are gated on verified operator origin (the `whisper` marker AND our server-side-apply field manager), not on spoofable provenance labels.
 - Synced copies strip the source finalizer and namespace annotation to prevent unintended re-sync.
 - The health check server binds to `0.0.0.0` — required for Kubernetes liveness/readiness probes.
+- The runtime image runs as non-root UID 65532; the chart sets a hardened `securityContext`.
 - Images and Helm charts are signed with cosign.
+
+## Design Decisions
+
+Durable design decisions are recorded as ADRs in [`docs/adr/`](docs/adr/):
+
+- [ADR 0001 — Cross-namespace sync authorization](docs/adr/0001-cross-namespace-sync-authorization.md)
+- [ADR 0002 — Security review remediation (v0.2.0)](docs/adr/0002-security-review-remediation.md)
+
+Prefer recording a new decision as an ADR (or a note in this file) over leaving it implicit, so it is version-controlled and reviewable.
 
 ## Known Issues / TODOs
 
-- `telemetry.rs` is a stub; tracing setup lives in `main.rs` directly.
-- The runtime Docker image uses `rust:latest` (large). Consider `debian:bookworm-slim` or distroless.
+- `telemetry.rs` is a stub; tracing setup lives in `main.rs` directly._(resolved: `telemetry.rs` now owns the OTLP pipelines and sets `service.name`.)_

--- a/docs/adr/0001-cross-namespace-sync-authorization.md
+++ b/docs/adr/0001-cross-namespace-sync-authorization.md
@@ -1,0 +1,62 @@
+# 1. Cross-namespace sync authorization
+
+Date: 2026-05-30
+
+Status: Accepted
+
+## Context
+
+whisperer copies a source Secret into other namespaces. A source Secret opts in
+with the label `whisperer.jeffl.es/sync=true` and lists target namespaces in the
+annotation `whisperer.jeffl.es/namespaces`. The operator runs with cluster-wide
+RBAC to read, write, and delete Secrets in every namespace.
+
+A security review (see [ADR 0002](0002-security-review-remediation.md)) found
+that trusting the source Secret's annotation alone to decide *where* to write was
+a Critical cross-tenant injection flaw: any user who can create a Secret in any
+one namespace could name an arbitrary target (e.g. `kube-system` or another
+tenant) and have the operator plant attacker-controlled data there using its
+cluster-wide privileges. The same review found the deletion logic trusted
+attacker-spoofable provenance labels (`whisperer.jeffl.es/whisper|name|namespace`)
+to decide *what* to delete, giving a cross-namespace data-destruction primitive.
+
+A `SubjectAccessReview` against the source Secret's creator was considered but
+rejected: the reconcile loop cannot reliably determine the creator's identity
+(managedFields / created-by annotations are absent or spoofable).
+
+## Decision
+
+**Writes — target namespaces must consent.** A namespace is only an eligible
+sync target if it carries `whisperer.jeffl.es/allow-sync=true` *and* is not
+protected. Consent is granted by whoever administers the target namespace, not by
+the author of the source Secret. Implemented as `is_consenting_namespace` /
+`resolve_targets` in `src/controller.rs`; requested-but-non-consenting namespaces
+are logged as "refused" and skipped.
+
+**Protected namespaces are never targets.** `kube-system`, `kube-public`,
+`kube-node-lease`, and the operator's own namespace (`CONTROLLER_NAMESPACE` env
+var) are refused even if labelled. See `PROTECTED_NAMESPACES` /
+`is_protected_namespace`.
+
+**Deletes — verify operator origin, not labels.** Every cross-namespace delete
+goes through `is_managed_copy`, which requires both the `whisper=true` marker
+*and* that the Secret was last applied by our server-side-apply field manager
+(`whisperer.jeffl.es`). `managedFields` is maintained by the API server and
+cannot be forged by a tenant, so a planted look-alike Secret cannot trick the
+operator into deleting a victim's data.
+
+We did **not** add a source-namespace allowlist. An earlier plan paired the
+target opt-in with a source-namespace restriction, but the target consent label
+plus protected-namespace denylist were judged sufficient and simpler; revisit if
+a need to restrict which namespaces may *originate* syncs emerges.
+
+## Consequences
+
+- Existing deployments must label each target namespace
+  `whisperer.jeffl.es/allow-sync=true` or their copies stop being updated. This
+  is a breaking change, documented in the README and the v0.2.0 release notes.
+- The cluster-wide RBAC grant remains (it is required for the operator to
+  function); the consent label and origin check are the application-layer
+  controls that make that grant safe to hold.
+- The pure decision functions (`is_consenting_namespace`, `resolve_targets`,
+  `is_protected_namespace`, `is_managed_copy`) are unit-tested in CI.

--- a/docs/adr/0002-security-review-remediation.md
+++ b/docs/adr/0002-security-review-remediation.md
@@ -1,0 +1,62 @@
+# 2. Security review remediation (v0.2.0)
+
+Date: 2026-05-30
+
+Status: Accepted
+
+## Context
+
+A full OWASP/CWE security review of whisperer (run against `main` at `8b07c41`)
+produced 11 findings across 26 hotspots: 1 Critical, 4 High, 2 Medium, 4 Low.
+Two root causes:
+
+1. The controller trusted user-authored Secret labels/annotations for both where
+   it writes and what it deletes, with no authorization gate or tamper-proof
+   source binding.
+2. The CI/CD pipeline ran untrusted code on persistent self-hosted runners and
+   signed images with an unverified `cosign` binary.
+
+The review identified three compound attack chains: (a) cross-tenant injection →
+privilege escalation via the then-root operator pod; (b) injection + spoofed-label
+deletion → full cross-tenant control of Secrets; (c) fork-PR RCE on the runner →
+poisoning of the signed, published image.
+
+## Decision
+
+Remediate before the first hardened release (v0.2.0).
+
+**Controller** (detailed in [ADR 0001](0001-cross-namespace-sync-authorization.md)):
+target-namespace consent label, protected-namespace denylist, and origin-verified
+deletes. Plus: metric labels no longer carry user-controlled name/namespace
+(cardinality-explosion DoS), and `Record::drop` no longer panics on clock skew.
+
+**Image & chart.** Runtime image moved from `rust:latest` (root, large) to
+`debian:bookworm-slim` with a fixed non-root UID 65532. The chart sets a hardened
+pod `securityContext` (`runAsNonRoot`, `runAsUser: 65532`, `readOnlyRootFilesystem`,
+drop `ALL`, seccomp `RuntimeDefault`) and pins `image.tag` to the chart
+appVersion instead of the mutable `latest`, preserving cosign digest pinning.
+
+**CI/CD.** The self-hosted `rust` job no longer runs on forked PRs. `cosign` is
+installed via the SHA-pinned first-party `sigstore/cosign-installer` instead of an
+unverified `curl | chmod`. Image and chart digests are validated before signing.
+Dependency auditing uses `rustsec/audit-check` (no `cargo install` from crates.io,
+which was unreliable on the runner). `dependabot-auto-merge` uses
+`pull_request_target` and documents that `--auto` relies on required
+branch-protection checks as the CI gate.
+
+**Accepted as-is (not findings).** Cluster-wide Secret RBAC and the mounted
+ServiceAccount token are required for a cross-namespace syncer to function. The
+leader-election Lease trust model is inherent to Kubernetes Leases and governed
+by RBAC. The `/ruok` health endpoint on `0.0.0.0` is required for probes.
+
+## Consequences
+
+- Shipped as **v0.2.0**. PRs: #107 (cleanup), #108 (controller + chart + CI
+  hardening, non-root image), #109 (unit tests for the authz logic), #110
+  (telemetry `service.name`).
+- Breaking change: target namespaces must opt in (see ADR 0001).
+- **Caveat:** the non-root image builds and is signed in CI but had not been run
+  on a live cluster as part of the release. Validate `runAsNonRoot` /
+  `readOnlyRootFilesystem` behaviour on a real cluster.
+- The hardened `securityContext` requires the image to run as a non-root UID;
+  the non-root Dockerfile and the chart default are coupled and must stay in sync.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+Durable design decisions for whisperer live here, one Markdown file per decision,
+numbered in order. Each record states the context, the decision, and its
+consequences. See [Michael Nygard's ADR pattern](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+Prefer recording a decision here (or in the project `CLAUDE.md`) over leaving it
+implicit in code or in out-of-band notes, so it is version-controlled and
+reviewable alongside the change that introduces it.
+
+- [0001 — Cross-namespace sync authorization](0001-cross-namespace-sync-authorization.md)
+- [0002 — Security review remediation (v0.2.0)](0002-security-review-remediation.md)


### PR DESCRIPTION
Records whisperer's durable design decisions in-repo (ADRs + CLAUDE.md) instead of leaving them implicit, so they're version-controlled and reviewable.

## Added
- **`docs/adr/0001-cross-namespace-sync-authorization.md`** — the authorization model: target namespaces consent via `whisperer.jeffl.es/allow-sync=true`, protected-namespace denylist, and origin-verified deletes (the `whisper` marker **and** our SSA field manager). Documents why `SubjectAccessReview` and a source-namespace allowlist were considered and *not* used.
- **`docs/adr/0002-security-review-remediation.md`** — the security review (1 Critical, 4 High, 2 Medium, 4 Low), the three attack chains, and what shipped in v0.2.0 across controller / image / chart / CI, plus what was accepted as required-by-design.
- **`docs/adr/README.md`** — ADR index + convention.

## Updated `CLAUDE.md`
- Security Notes: document the `allow-sync` consent requirement and origin-verified deletes.
- New Design Decisions section pointing at the ADRs.
- Cleared the now-resolved Known Issues (telemetry stub, `rust:latest` image).

Docs only — no code change. These ADRs reflect **what actually shipped** in #108/#109/#110, which differs from an earlier plan (e.g. no source-namespace allowlist was added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
