### PR TITLE
ci: authenticate to BuildKit over mTLS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,12 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           driver: remote
-          endpoint: tcp://buildkit:1234
+          endpoint: tcp://buildkit.dev.svc.cluster.local:1234
+          # buildkit enforces mTLS; client cert is mounted into the runner pod.
+          driver-opts: |
+            cacert=/home/runner/buildkit-certs/ca.crt
+            cert=/home/runner/buildkit-certs/tls.crt
+            key=/home/runner/buildkit-certs/tls.key
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7


### PR DESCRIPTION
Point the remote buildx driver at the in-cluster BuildKit FQDN and pass the client cert mounted into the runner pod, matching the daemon's new mTLS config.

Part of the cluster security-hardening rollout (BuildKit now enforces mTLS + a NetworkPolicy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)