### PR TITLE
fix: repair broken v0.2.0 image (glibc + probes) and add default/overridable service.name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+# Builder must match the runtime's glibc. debian:bookworm-slim ships glibc 2.36;
+# the default cargo-chef:latest-rust-1 is a newer Debian (glibc 2.41), which
+# produces a binary that fails on bookworm with "GLIBC_2.39 not found". The
+# -bookworm tag is built on bookworm (glibc 2.36) so the two stay in sync.
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -88,11 +88,11 @@ resources: {}
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
-    path: /
+    path: /ruok
     port: http
 readinessProbe:
   httpGet:
-    path: /
+    path: /ruok
     port: http
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -10,9 +10,21 @@ use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, prelude::*};
 
 use crate::metrics::MetricState;
 
-/// Service name attached to every span and metric. Without a `service.name`
-/// resource attribute, collectors label our telemetry `unknown_service`.
-const SERVICE_NAME: &str = "whisperer";
+/// Default service name attached to every span and metric when the operator
+/// hasn't supplied one. Without a `service.name` resource attribute, collectors
+/// label our telemetry `unknown_service`. An operator can override this with the
+/// standard `OTEL_SERVICE_NAME` (or `OTEL_RESOURCE_ATTRIBUTES=service.name=...`)
+/// environment variable.
+const DEFAULT_SERVICE_NAME: &str = "whisperer";
+
+/// True if the operator has already specified a service name via the standard
+/// OpenTelemetry environment variables, in which case we must not override it.
+fn service_name_set_in_env() -> bool {
+    std::env::var_os("OTEL_SERVICE_NAME").is_some()
+        || std::env::var("OTEL_RESOURCE_ATTRIBUTES")
+            .map(|v| v.contains("service.name"))
+            .unwrap_or(false)
+}
 
 // Telemetry setup follows the patterns from:
 // - https://github.com/kube-rs/controller-rs/blob/main/src/telemetry.rs
@@ -47,8 +59,16 @@ impl Telemetry {
 /// Returns a [`Telemetry`] guard that must be kept alive and shut down on exit.
 pub fn init() -> Result<Telemetry> {
     // Identify this process to the collector so spans and metrics are attributed
-    // to "whisperer" rather than the default "unknown_service".
-    let resource = Resource::builder().with_service_name(SERVICE_NAME).build();
+    // to a real service rather than the default "unknown_service". Honor an
+    // operator-supplied OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES (already
+    // read by Resource::builder()'s env detector); only fall back to our default
+    // when neither is set.
+    let builder = Resource::builder();
+    let resource = if service_name_set_in_env() {
+        builder.build()
+    } else {
+        builder.with_service_name(DEFAULT_SERVICE_NAME).build()
+    };
 
     let span_exporter = SpanExporter::builder().with_http().build()?;
     let tracer_provider = SdkTracerProvider::builder()
@@ -56,7 +76,8 @@ pub fn init() -> Result<Telemetry> {
         .with_resource(resource.clone())
         .with_batch_exporter(span_exporter)
         .build();
-    let otel = tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer(SERVICE_NAME));
+    let otel =
+        tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer(DEFAULT_SERVICE_NAME));
     let filter = EnvFilter::from_default_env();
     tracing_subscriber::registry()
         .with(otel)
@@ -87,7 +108,7 @@ pub fn init() -> Result<Telemetry> {
         .with_resource(resource)
         .with_periodic_exporter(metric_exporter)
         .build();
-    let metrics = MetricState::new(meter_provider.meter(SERVICE_NAME));
+    let metrics = MetricState::new(meter_provider.meter(DEFAULT_SERVICE_NAME));
 
     Ok(Telemetry {
         tracer_provider,


### PR DESCRIPTION
Cluster-testing the v0.2.0 image (as requested) surfaced **two release-blocking bugs** and implements the requested OTel service-name default.

## 🔴 v0.2.0's published image does not run
1. **glibc mismatch → CrashLoopBackOff.** The builder was `cargo-chef:latest-rust-1` (newer Debian, **glibc 2.41**) while the runtime is `debian:bookworm-slim` (**glibc 2.36**). The binary fails at startup with `GLIBC_2.39 not found`. Fix: pin the builder to `lukemathwalker/cargo-chef:latest-rust-1-bookworm` so builder and runtime share glibc 2.36. _(My earlier Dockerfile comment claimed they matched — they didn't; only verified once run on a cluster.)_
2. **Health probes 404 → restart loop.** The chart's liveness/readiness probes hit `/`, but the server only serves `/ruok`. Every probe returned 404, so the kubelet killed the pod repeatedly. Fix: point both probes at `/ruok`.

## ✨ service.name default + override (requested)
`telemetry::init` now applies a default `service.name="whisperer"` **only when the operator hasn't set one**, honoring the standard `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` env vars (read by the SDK's resource env detector) when present.

## Verified on a live k3d cluster
- Image runs as non-root `uid=65532`.
- Pod **1/1 Running, 0 restarts** (was CrashLoopBackOff).
- A source secret targeting an `allow-sync=true` namespace + a non-consenting namespace + `kube-system` synced **only into the consenting one**.
- `cargo build` / `clippy` (0 warnings) / `nextest` (12 pass, 1 skip) / `fmt` / `helm lint` all clean.

## Note
v0.2.0's image is non-functional, so this should ship as **v0.2.1** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
