### PR TITLE
test: opt target namespaces into sync in the live-cluster integration test

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -599,13 +599,20 @@ mod test {
         let lp = ListParams::default().labels(&format!("{ACTIVE_LABEL}=true"));
         let nsapi: Api<Namespace> = Api::all(client.clone());
         let namespaces = ["source", "target", "target2", "clean"];
+        // Targets must consent with allow-sync=true before whisperer will sync
+        // into them; "source" and "clean" deliberately don't opt in.
+        let consenting = ["target", "target2"];
         for ns in namespaces {
+            let labels = consenting
+                .contains(&ns)
+                .then(|| BTreeMap::from([(ALLOW_SYNC_LABEL.to_string(), "true".to_string())]));
             nsapi
                 .create(
                     &PostParams::default(),
                     &Namespace {
                         metadata: ObjectMeta {
                             name: Some(ns.to_string()),
+                            labels,
                             ..ObjectMeta::default()
                         },
                         ..Namespace::default()


### PR DESCRIPTION
## Why

`controller::test::sync_and_delete_works` (the `#[ignore = "uses k8s api"]` live-cluster test) predates the **allow-sync consent gate** added in v0.2.x. It created the target namespaces without `whisperer.jeffl.es/allow-sync=true`, so under the current contract `apply()` refuses them and the `"secret is synced"` assertion fails. The test was silently stale — it never runs in CI, so nothing caught it.

## What

Label the two real targets (`target`, `target2`) with `allow-sync=true` when creating them; `source` and `clean` intentionally stay unlabelled.

## Verification

Ran the full suite against a fresh **k3d** cluster:

```
cargo nextest run --run-ignored all
  Summary  13 tests run: 13 passed, 0 skipped
```

Default (no-cluster) suite, clippy, and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)