### PR TITLE
fix(ci): publish bare-semver image tags so the chart can pull them

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,14 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Emit the bare semver (v0.2.2 tag -> image tag 0.2.2) so the published
+          # image matches what the Helm chart pulls by default
+          # (image.tag | default .Chart.AppVersion, which has no leading "v").
+          # The default type=ref,event=tag would keep the "v" and the chart
+          # would request a tag that does not exist.
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:


### PR DESCRIPTION
## Bug

The published image tag doesn't match what the Helm chart pulls:

- `docker/metadata-action` had **no `tags:` config**, so on a tag push it used the default `type=ref,event=tag` → image tag **`v0.2.2`** (leading `v`).
- The chart deploys `{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}`, and `Chart.AppVersion` is **`0.2.2`** (no `v`).

So a default `helm install` requests `ghcr.io/thejefflarson/whisperer:0.2.2`, which was never published — only `v0.2.2` exists. The image pull fails.

## Fix

Configure `metadata-action` tags explicitly:

```yaml
tags: |
  type=semver,pattern={{version}}                      # v0.2.2 -> 0.2.2
  type=raw,value=latest,enable={{is_default_branch}}
```

`type=semver,pattern={{version}}` strips the leading `v`, so the published image tag matches the chart's request.

## Effect & follow-up

Takes effect on the **next** release tag. The current v0.2.2 chart still points at the missing `0.2.2` image, so after this merges I'll cut **v0.2.3** to produce a correctly-named image + matching chart (a clean working pair). v0.2.2 is left as-is.

YAML validated. CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)