### PR TITLE
fix(telemetry): register tracer and meter providers globally

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use opentelemetry::{metrics::MeterProvider, trace::TracerProvider as _};
+use opentelemetry::{global, metrics::MeterProvider, trace::TracerProvider as _};
 use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
     Resource,
@@ -76,6 +76,10 @@ pub fn init() -> Result<Telemetry> {
         .with_resource(resource.clone())
         .with_batch_exporter(span_exporter)
         .build();
+    // Register globally so spans created via the OpenTelemetry global API (not
+    // just our tracing layer) also carry service.name; without this they fall
+    // back to a no-op provider and lose the resource.
+    global::set_tracer_provider(tracer_provider.clone());
     let otel =
         tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer(DEFAULT_SERVICE_NAME));
     let filter = EnvFilter::from_default_env();
@@ -108,6 +112,9 @@ pub fn init() -> Result<Telemetry> {
         .with_resource(resource)
         .with_periodic_exporter(metric_exporter)
         .build();
+    // Same as the tracer: make this the global meter provider so any metrics
+    // recorded through the global API are attributed to service.name too.
+    global::set_meter_provider(meter_provider.clone());
     let metrics = MetricState::new(meter_provider.meter(DEFAULT_SERVICE_NAME));
 
     Ok(Telemetry {


### PR DESCRIPTION
## Symptom

`service.name` showed up as `whisperer` only intermittently in OTel — appearing briefly, then reverting to the default/`unknown_service`.

## Cause

`telemetry::init()` built the `SdkTracerProvider` / `SdkMeterProvider` **with** the `service.name` resource, but only attached them to our `tracing` layer and the controller's `MetricState`. Telemetry that resolves the OpenTelemetry **global** provider (the default path for anything not going through our explicit handles, including some library instrumentation) hit the no-op global provider — losing the resource, hence the inconsistent `service.name`.

## Fix

Register the configured providers globally:

```rust
global::set_tracer_provider(tracer_provider.clone());
global::set_meter_provider(meter_provider.clone());
```

They're cheap `Clone` handles; `Telemetry::shutdown()` still flushes via the owned copies. Now every code path — ours and the global API — is backed by a provider carrying `service.name`.

## Verification

`cargo build` / `clippy --all-targets` (0 warnings) / `nextest` (12 passed, 1 skipped) / `fmt --check` — all clean.

Note: code/build-verified; the intermittent attribution can't be reproduced without a live collector here, but this closes the gap that caused it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)