### PR TITLE
fix: no ANSI colors in piped (prod) logs; release 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "whisperer"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "whisperer"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
+# `cargo run` is ambiguous with the crdgen bin; default to the operator.
+default-run = "whisperer"
 
 [dependencies]
 anyhow = "1.0.102"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.1"
+appVersion: "0.3.2"

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use opentelemetry::{global, metrics::MeterProvider, trace::TracerProvider as _};
 use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
@@ -83,9 +85,13 @@ pub fn init() -> Result<Telemetry> {
     let otel =
         tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer(DEFAULT_SERVICE_NAME));
     let filter = EnvFilter::from_default_env();
+    // tracing-subscriber's fmt layer defaults ANSI colors ON with no TTY
+    // detection, so in Kubernetes (stdout piped to a log collector) the escape
+    // codes end up in the logs. Only colorize when stdout is a real terminal.
+    let ansi = std::io::stdout().is_terminal();
     tracing_subscriber::registry()
         .with(otel)
-        .with(fmt::layer().with_filter(filter))
+        .with(fmt::layer().with_ansi(ansi).with_filter(filter))
         .init();
 
     // Warn when OTLP goes over plaintext HTTP to a non-loopback address — metric


### PR DESCRIPTION
The operator's logs were carrying ANSI color escape codes in production. `tracing-subscriber`'s fmt layer defaults ANSI **on** and does no TTY detection, so when stdout is piped to a log collector (Kubernetes) the escapes land in the logs. Fix: colorize only when stdout is a real terminal (`std::io::IsTerminal`) — local `cargo run` keeps colors, prod gets clean logs.

Verified: a real piped INFO line now has **zero** escape bytes (`cat -v` clean); on a TTY colors still render.

Also adds `default-run = "whisperer"` so bare `cargo run` works again (the `crdgen` bin made it ambiguous, and the docs reference `cargo run`).

Patch release **0.3.2** (0.3.1 is taken by #126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)