### PR TITLE
fix: close contract-review gaps (adopt-prevention, leader fencing, target confinement)

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -34,11 +34,15 @@ cleanup() {
 trap cleanup EXIT
 
 echo "==> creating k3d cluster '$CLUSTER'"
-k3d cluster create "$CLUSTER" --wait --no-lb --k3s-arg "--disable=traefik@server:0"
+# Don't let k3d merge this throwaway cluster into the caller's default kubeconfig
+# (we write our own below). This also silences k3d's "multiple kubeconfigs
+# specified via KUBECONFIG" warning when the caller's KUBECONFIG lists several.
+k3d cluster create "$CLUSTER" --wait --no-lb \
+  --kubeconfig-update-default=false --kubeconfig-switch-context=false \
+  --k3s-arg "--disable=traefik@server:0"
 
-# Point kubectl/kube-rs at the new cluster for the rest of this script. Set a
-# single path (k3d warns if KUBECONFIG already lists several) so neither kubectl
-# nor kube-rs touches the developer's real clusters.
+# Point kubectl/kube-rs at the new cluster for the rest of this script via a
+# single dedicated kubeconfig, so neither touches the developer's real clusters.
 unset KUBECONFIG
 export KUBECONFIG
 KUBECONFIG="$(k3d kubeconfig write "$CLUSTER")"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -215,10 +215,18 @@ fn resolve_targets(wanted: &NSSet, namespaces: &[Namespace]) -> TargetResolution
 ///
 /// A namespace is a target only if it exists, consents
 /// (`whisperer.jeffl.es/allow-sync=true`) and isn't protected — the authorization
-/// boundary — *and* isn't being decommissioned (`drain`). Draining namespaces are
-/// excluded here, alongside the other never-a-target rules, so every caller of
-/// `resolve` gets real targets without re-applying the exclusion.
-async fn resolve(wanted: &NSSet, drain: &NSSet, client: &Client) -> Result<NSSet, Error> {
+/// boundary — isn't being decommissioned (`drain`), AND (when `write` is
+/// configured) is one of the namespaces we're allowed to write into. Confining
+/// targets to `write` keeps the set we WRITE identical to the set
+/// orphan-recovery PROBES (`discover_copies`), so a copy can never land in a
+/// namespace we'd later be unable to find and reclaim. Every caller of `resolve`
+/// gets real targets without re-applying any of these exclusions.
+async fn resolve(
+    wanted: &NSSet,
+    write: &NSSet,
+    drain: &NSSet,
+    client: &Client,
+) -> Result<NSSet, Error> {
     let all = Api::<Namespace>::all(client.clone())
         .list(&ListParams::default())
         .await
@@ -238,7 +246,29 @@ async fn resolve(wanted: &NSSet, drain: &NSSet, client: &Client) -> Result<NSSet
         );
     }
 
-    Ok(resolution.targets.difference(drain).cloned().collect())
+    let mut targets = resolution
+        .targets
+        .difference(drain)
+        .cloned()
+        .collect::<NSSet>();
+
+    // Confine to writeNamespaces (when set): a consenting target we can't write
+    // into is also one we can't probe/reclaim, so refuse it here rather than
+    // letting the write fail at the API server and leave an untrackable copy.
+    // An empty `write` means unconfigured (e.g. local `cargo run`); keep the
+    // consent-only behaviour there.
+    if !write.is_empty() {
+        let outside = targets.difference(write).cloned().collect::<Vec<_>>();
+        if !outside.is_empty() {
+            warn!(
+                "requested namespaces '{}' are not in writeNamespaces; refusing to sync there (the operator can't reclaim copies it can't write)",
+                outside.join(",")
+            );
+            targets.retain(|t| write.contains(t));
+        }
+    }
+
+    Ok(targets)
 }
 
 /// What a single reconcile should do to the cluster: write a copy into every
@@ -297,9 +327,16 @@ async fn apply(whisper: Arc<Whisper>, ctx: Arc<Context>) -> Result<Action, Error
     };
 
     let wanted = whisper.spec.namespaces.iter().cloned().collect::<NSSet>();
-    // `resolve` excludes draining namespaces, so a target moved to `drainNamespaces`
-    // falls out of `targets` and its copy is reclaimed (into `to_delete`) below.
-    let targets = resolve(&wanted, &ctx.drain_namespaces, client).await?;
+    // `resolve` excludes draining namespaces and confines to writeNamespaces, so a
+    // target moved to `drainNamespaces` falls out of `targets` and its copy is
+    // reclaimed (into `to_delete`) below.
+    let targets = resolve(
+        &wanted,
+        &ctx.write_namespaces,
+        &ctx.drain_namespaces,
+        client,
+    )
+    .await?;
 
     // Where copies live is the status record UNION what a name-probe of the
     // write namespaces actually finds. Status is the fast path; the probe makes
@@ -317,6 +354,14 @@ async fn apply(whisper: Arc<Whisper>, ctx: Arc<Context>) -> Result<Action, Error
         to_write,
         to_delete,
     } = plan(&synced, &targets);
+
+    // Leadership can be lost between the dispatcher's check and here (the reads
+    // above are async). Re-check before any write/delete so a replica that has
+    // stepped down doesn't mutate secrets on a lease another replica may now hold.
+    if !ctx.state.is_leader() {
+        info!("no longer leader; deferring reconcile of '{copy_name}'");
+        return Ok(Action::requeue(Duration::from_secs(5)));
+    }
 
     // Orphans are namespaces we synced into before but aren't targets now. We
     // know them from status plus the probe, so we delete by name in those
@@ -342,6 +387,19 @@ async fn apply(whisper: Arc<Whisper>, ctx: Arc<Context>) -> Result<Action, Error
     // place rather than leaving an old-named orphan.
     for ns in &to_write {
         let api: Api<Secret> = Api::namespaced(client.clone(), ns);
+        // Never adopt a pre-existing secret we didn't create: if an object of this
+        // name already exists in the target and isn't one of our copies, refuse to
+        // overwrite it. Otherwise the server-side apply would stamp our ownership
+        // markers onto someone else's secret (clobbering its data and letting a
+        // later cleanup delete it). Skip with a warning rather than churn.
+        if let Some(existing) = api.get_opt(&copy_name).await.map_err(Error::GetSecret)?
+            && !is_owned_copy(&existing, &owner_uid)
+        {
+            warn!(
+                "refusing to sync '{copy_name}' into '{ns}': a secret of that name already exists there and is not a whisperer copy"
+            );
+            continue;
+        }
         let copy = secret.dup(&copy_name, &owner_uid, &namespace, ns.clone());
         let res = api
             .patch(
@@ -448,6 +506,14 @@ async fn delete_copy(
 /// user's.
 #[instrument(skip(ctx, whisper))]
 async fn cleanup(whisper: Arc<Whisper>, ctx: Arc<Context>) -> Result<Action> {
+    // Re-check leadership before deleting (the dispatcher's check may be stale).
+    if !ctx.state.is_leader() {
+        info!(
+            "no longer leader; deferring cleanup of '{}'",
+            whisper.name_any()
+        );
+        return Ok(Action::requeue(Duration::from_secs(5)));
+    }
     let copy_name = whisper.name_any();
     let owner_uid = whisper.uid().unwrap_or_default();
     let mut copies = whisper
@@ -970,37 +1036,9 @@ mod test {
             .unwrap();
 
         // Build a leader Context with the given write/drain namespace sets.
-        let make_ctx = |write: &[&str], drain: &[&str]| {
-            let recorder = Recorder::new(
-                client.clone(),
-                Reporter {
-                    controller: "whisperer".into(),
-                    instance: env::var("CONTROLLER_POD_NAME").ok(),
-                },
-            );
-            let exporter = MetricExporter::builder()
-                .with_http()
-                .with_protocol(Protocol::HttpBinary)
-                .build()
-                .unwrap();
-            let provider = SdkMeterProvider::builder()
-                .with_periodic_exporter(exporter)
-                .build();
-            let metrics = MetricState::new(provider.meter("whisperer"));
-            let (_, rx) = watch::channel(State::Leading);
-            Arc::new(Context {
-                client: client.clone(),
-                recorder,
-                metrics,
-                state: LeaderState::new(rx),
-                write_namespaces: write.iter().map(|s| s.to_string()).collect(),
-                drain_namespaces: drain.iter().map(|s| s.to_string()).collect(),
-            })
-        };
-
         // The operator may write into both consenting targets; this is also the
         // set the orphan name-probe scans.
-        let data = make_ctx(&["target", "target2"], &[]);
+        let data = leader_ctx(&client, &["target", "target2"], &[]);
 
         // Copies are identified cluster-wide by the whisper marker label.
         let all_secrets = Api::<Secret>::all(client.clone());
@@ -1118,7 +1156,7 @@ mod test {
         // spec and still consents). The operator must NOT write there anymore and
         // must reclaim the copy already in it — proving a namespace can be drained
         // without stranding copies, even before it's removed from the spec.
-        let drain = make_ctx(&["target2"], &["target"]);
+        let drain = leader_ctx(&client, &["target2"], &["target"]);
         let whisper = Arc::new(whispers.get_status("sync").await.unwrap());
         let _ = apply(whisper, drain).await.unwrap();
         let items = all_secrets.list(&copy_params).await.unwrap().items;
@@ -1156,5 +1194,137 @@ mod test {
                 namespaces,
             },
         )
+    }
+
+    /// Build a leader `Context` for live-cluster tests with the given write/drain
+    /// namespace sets.
+    fn leader_ctx(client: &Client, write: &[&str], drain: &[&str]) -> Arc<Context> {
+        let recorder = Recorder::new(
+            client.clone(),
+            Reporter {
+                controller: "whisperer".into(),
+                instance: env::var("CONTROLLER_POD_NAME").ok(),
+            },
+        );
+        let exporter = MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build()
+            .unwrap();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter)
+            .build();
+        let metrics = MetricState::new(provider.meter("whisperer"));
+        let (_, rx) = watch::channel(State::Leading);
+        Arc::new(Context {
+            client: client.clone(),
+            recorder,
+            metrics,
+            state: LeaderState::new(rx),
+            write_namespaces: write.iter().map(|s| s.to_string()).collect(),
+            drain_namespaces: drain.iter().map(|s| s.to_string()).collect(),
+        })
+    }
+
+    /// A Whisper whose name collides with a pre-existing, non-whisperer secret in
+    /// a consenting target must NOT adopt or overwrite it (which would also let a
+    /// later cleanup delete it). Covers the contract-review finding.
+    #[tokio::test]
+    #[ignore = "uses k8s api"]
+    async fn apply_refuses_to_adopt_foreign_secret() {
+        let client = Client::try_default().await.unwrap();
+        let nsapi: Api<Namespace> = Api::all(client.clone());
+        for (name, consents) in [("adopt-src", false), ("adopt-tgt", true)] {
+            let labels = consents
+                .then(|| BTreeMap::from([(ALLOW_SYNC_LABEL.to_string(), "true".to_string())]));
+            nsapi
+                .create(
+                    &PostParams::default(),
+                    &Namespace {
+                        metadata: ObjectMeta {
+                            name: Some(name.to_string()),
+                            labels,
+                            ..ObjectMeta::default()
+                        },
+                        ..Namespace::default()
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        // Source secret the Whisper replicates.
+        let src: Api<Secret> = Api::namespaced(client.clone(), "adopt-src");
+        let mk = |name: &str, ns: &str, val: &[u8], fm: &str| {
+            let s = Secret {
+                data: Some(BTreeMap::from([(
+                    "k".to_string(),
+                    ByteString(val.to_vec()),
+                )])),
+                metadata: ObjectMeta {
+                    name: Some(name.to_string()),
+                    namespace: Some(ns.to_string()),
+                    ..ObjectMeta::default()
+                },
+                ..Secret::default()
+            };
+            (s, PatchParams::apply(fm))
+        };
+        let (s, pp) = mk("s", "adopt-src", b"ours", "whisperer.jeffl.es");
+        src.patch("s", &pp, &Patch::Apply(&s)).await.unwrap();
+
+        // A PRE-EXISTING foreign secret named after the Whisper ("adopt"), written
+        // by a different field manager, with no whisperer markers.
+        let tgt: Api<Secret> = Api::namespaced(client.clone(), "adopt-tgt");
+        let (victim, vpp) = mk("adopt", "adopt-tgt", b"victim", "someone-else");
+        tgt.patch("adopt", &vpp, &Patch::Apply(&victim))
+            .await
+            .unwrap();
+
+        // Whisper named "adopt" -> its copy name collides with the victim secret.
+        let whispers: Api<Whisper> = Api::namespaced(client.clone(), "adopt-src");
+        let whisper = Whisper::new(
+            "adopt",
+            WhisperSpec {
+                secret_name: "s".to_string(),
+                namespaces: vec!["adopt-tgt".to_string()],
+            },
+        );
+        whispers
+            .patch(
+                "adopt",
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Apply(&whisper),
+            )
+            .await
+            .unwrap();
+
+        let data = leader_ctx(&client, &["adopt-tgt"], &[]);
+        let whisper = Arc::new(whispers.get("adopt").await.unwrap());
+        let _ = apply(whisper, data).await.unwrap();
+
+        // The victim must be untouched: original data, no owner-uid stamped.
+        let after = tgt.get("adopt").await.unwrap();
+        assert_eq!(
+            after.data.unwrap().get("k").unwrap().0,
+            b"victim",
+            "foreign secret data must not be overwritten"
+        );
+        assert!(
+            !after
+                .metadata
+                .labels
+                .unwrap_or_default()
+                .contains_key(OWNER_UID_LABEL),
+            "foreign secret must not be adopted (no owner-uid stamped)"
+        );
+
+        whispers
+            .delete("adopt", &DeleteParams::default())
+            .await
+            .unwrap();
+        for ns in ["adopt-src", "adopt-tgt"] {
+            nsapi.delete(ns, &DeleteParams::default()).await.unwrap();
+        }
     }
 }

--- a/src/election.rs
+++ b/src/election.rs
@@ -273,37 +273,41 @@ async fn transition<F, Fut>(
     lease_result: Result<Option<Lease>>,
     operation: F,
     context: &str,
-) -> (State, bool)
+    state_tx: &watch::Sender<State>,
+) -> Result<State>
 where
     F: FnOnce(State, Api<Lease>, Option<Lease>) -> Fut,
     Fut: Future<Output = Result<State, Error>>,
 {
-    let new_state = {
-        // Extract the lease or step down and back off on error.
-        let lease = match lease_result {
-            Ok(lease) => lease,
-            Err(err) => {
-                warn!(error = ?err, context = context, "Lease operation failed");
-                let demoted = fail_safe(&current_state);
-                sleep(Duration::from_secs(BACKOFF)).await;
-                return (demoted.clone(), current_state != demoted);
-            }
-        };
-
-        // Perform the operation or step down and back off on error.
-        match operation(current_state.clone(), api, lease).await {
-            Ok(new_state) => new_state,
+    // Compute the next state; on any failure step down (fail_safe) and remember to
+    // back off afterwards.
+    let (new_state, errored) = match lease_result {
+        Err(err) => {
+            warn!(error = ?err, context = context, "Lease operation failed");
+            (fail_safe(&current_state), true)
+        }
+        Ok(lease) => match operation(current_state.clone(), api, lease).await {
+            Ok(new_state) => (new_state, false),
             Err(err) => {
                 warn!(error = ?err, context = context, "State transition failed");
-                let demoted = fail_safe(&current_state);
-                sleep(Duration::from_secs(BACKOFF)).await;
-                demoted
+                (fail_safe(&current_state), true)
             }
-        }
+        },
     };
 
-    let changed = current_state != new_state;
-    (new_state, changed)
+    // Publish the new state BEFORE backing off. Reconciliation gates on
+    // `is_leader()` reading this channel, so a step-down must be visible
+    // immediately — sleeping first would leave the operator reconciling as a
+    // leader it has already decided it is not, for the whole backoff.
+    if new_state != current_state {
+        state_tx
+            .send(new_state.clone())
+            .map_err(|_| Error::ChannelSend)?;
+    }
+    if errored {
+        sleep(Duration::from_secs(BACKOFF)).await;
+    }
+    Ok(new_state)
 }
 
 const LOCK_NAME: &str = "whisperer-controller-lock";
@@ -335,43 +339,34 @@ pub(crate) async fn start(client: Client) -> (LeaderState, LeaderLock) {
             });
             select! {
                 change = deleted => {
-                    let (new_state, changed) = transition(
+                    state = transition(
                         state,
                         api.clone(),
                         change.map_err(Error::Watch),
                         acquire,
-                        "Lease creation failed"
-                    ).await;
-                    state = new_state;
-                    if changed {
-                        state_tx.send(state.clone()).map_err(|_| Error::ChannelSend)?;
-                    }
+                        "Lease creation failed",
+                        &state_tx,
+                    ).await?;
                 },
                 change = owner_changed => {
-                    let (new_state, changed) = transition(
+                    state = transition(
                         state,
                         api.clone(),
                         change.map_err(Error::Watch),
                         new_owner,
-                        "Owner change operation failed"
-                    ).await;
-                    state = new_state;
-                    if changed {
-                        state_tx.send(state.clone()).map_err(|_| Error::ChannelSend)?;
-                    }
+                        "Owner change operation failed",
+                        &state_tx,
+                    ).await?;
                 },
                 _ = timer => {
-                    let (new_state, changed) = transition(
+                    state = transition(
                         state,
                         api.clone(),
                         Ok(None),
                         renew,
-                        "Timer operation failed"
-                    ).await;
-                    state = new_state;
-                    if changed {
-                        state_tx.send(state.clone()).map_err(|_| Error::ChannelSend)?;
-                    }
+                        "Timer operation failed",
+                        &state_tx,
+                    ).await?;
                 }
                 // we're done here
                 _ = &mut cancel_rx => break


### PR DESCRIPTION
Fixes the contract mismatches from `/soundcheck:contract-review`:

- **apply adopt-prevention** (the attacker-reachable one): refuse to SSA-write a copy onto a pre-existing secret of that name that isn't already ours, so the operator can't adopt — and later `cleanup`-delete — a foreign or another tenant's secret in a consenting target namespace. New live test `apply_refuses_to_adopt_foreign_secret`.
- **leader fencing**: re-check `is_leader()` at the top of `apply` and `cleanup`, so a replica that stepped down between dispatch and the reconcile body doesn't keep mutating secrets.
- **election step-down timing**: publish the `Standby` state to the watch channel *before* the backoff sleep, so `is_leader()` reflects the step-down immediately instead of lagging for the full backoff.
- **target confinement**: `resolve` now confines targets to `writeNamespaces` (when set), so "where we write" == "where orphan-recovery probes" — a copy can't land somewhere we couldn't later reclaim it.

Verified: unit + proptests, clippy clean, and k3d integration (incl. the new adopt test + existing sync/recovery/rename/drain) all green. No version bump — pure fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)