### PR TITLE
chore: release 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "whisperer"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisperer"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 # `cargo run` is ambiguous with the crdgen bin; default to the operator.
 default-run = "whisperer"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.2"
+appVersion: "0.3.3"


### PR DESCRIPTION
Patch release of the contract-review security hardening from #128 (adopt-prevention, leader fencing, election step-down timing, target confinement). Bumps Cargo.toml + Chart.yaml to 0.3.3.