### PR TITLE
ci: add SLSA provenance + SBOM attestations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache,mode=max
+          # SLSA build provenance + SBOM attestations, matching the other images.
+          provenance: mode=max
+          sbom: true
       # First-party installer verifies the cosign binary's own checksum, unlike
       # a bare curl|chmod of a release asset.
       - name: Install cosign


### PR DESCRIPTION
Brings whisperer's image build in line with the other first-party images: adds `provenance: mode=max` and `sbom: true` to the build-push-action so the published image carries SLSA build provenance and an SBOM alongside its keyless cosign signature.

Signing path was already modern (pinned cosign-installer, sign-by-digest, digest-format validation) — this just adds the attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)