### PR TITLE
feat(metrics): namespace metrics under whisperer.* (0.3.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "whisperer"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisperer"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 # `cargo run` is ambiguous with the crdgen bin; default to the operator.
 default-run = "whisperer"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.3"
+appVersion: "0.3.4"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -18,15 +18,15 @@ impl Metrics {
     pub fn new(meter: Meter) -> Self {
         Self {
             reconciliations: meter
-                .u64_counter("reconciliations")
+                .u64_counter("whisperer.reconciliations")
                 .with_description("number of reconciliations performed")
                 .build(),
             failures: meter
-                .u64_counter("failures")
+                .u64_counter("whisperer.failures")
                 .with_description("number of failed reconciliations")
                 .build(),
             duration: meter
-                .f64_histogram("duration")
+                .f64_histogram("whisperer.duration")
                 .with_description("duration of reconciliation attempts")
                 .with_unit("ms")
                 .build(),


### PR DESCRIPTION
Prefixes the three OpenTelemetry instruments with a `whisperer.` namespace so they don't collide with other operators' metrics in a shared collector:

- `reconciliations` → `whisperer.reconciliations`
- `failures` → `whisperer.failures`
- `duration` → `whisperer.duration`

OTel uses dot-separated namespaces natively; the Prometheus exporter normalizes the dots to underscores (`whisperer_reconciliations`, …). No dashboards or tests referenced the old bare names.

Bumps Cargo + chart to 0.3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)